### PR TITLE
Add command-line arguments for syncing and specifying password

### DIFF
--- a/CanvasSync/CanvasEntities/synchronizer.py
+++ b/CanvasSync/CanvasEntities/synchronizer.py
@@ -46,7 +46,7 @@ class Synchronizer(Entity):
         """
 
         if not settings.is_loaded():
-            settings.load_settings()
+            settings.load_settings("")
 
         # Start sync by clearing the console window
         static_functions.clear_console()

--- a/CanvasSync/Settings/cryptography.py
+++ b/CanvasSync/Settings/cryptography.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 # Inbuilt modules
 import getpass
 import os.path
+import sys
 
 # Third party modules
 import bcrypt
@@ -65,7 +66,7 @@ def encrypt(message):
     return encrypted_message
 
 
-def decrypt(message):
+def decrypt(message, password):
     """
     Decrypts an AES encrypted string
     """
@@ -79,13 +80,24 @@ def decrypt(message):
 
     # Get password from user and compare to answer
     valid_password = False
-    while not valid_password:
-        print(u"\nPlease enter password to decrypt the settings file:")
-        password = getpass.getpass()
+
+    # If the password isn't null then it was specified as a command-line argument
+    if not password == "":
         if bcrypt.hashpw(password, hashed_password) == hashed_password:
             valid_password = True
         else:
-            print(u"\n[ERROR] Invalid password. Invoke CanvasSync with the -s flag to reset settings.")
+            print(u"\n[ERROR] Invalid password. Please try again or invoke CanvasSync with the -s flag to reset settings.")
+            sys.exit()
+
+    # Otherwise, get the password from the user
+    else:
+        while not valid_password:
+            print(u"\nPlease enter password to decrypt the settings file:")
+            password = getpass.getpass()
+            if bcrypt.hashpw(password, hashed_password) == hashed_password:
+                valid_password = True
+            else:
+                print(u"\n[ERROR] Invalid password. Please try again or invoke CanvasSync with the -s flag to reset settings.")
 
     # Read the remote IV
     remoteIV = message[:16]

--- a/CanvasSync/Settings/settings.py
+++ b/CanvasSync/Settings/settings.py
@@ -73,7 +73,7 @@ class Settings(object):
     def is_loaded(self):
         return self.sync_path != u"Not set" and self.domain != u"Not set" and self.token != u"Not set" and self.courses_to_sync[0] != u"Not set"
 
-    def load_settings(self):
+    def load_settings(self, password):
         """ Loads the current settings from the settings file and sets the attributes of the Settings object """
 
         if self.is_loaded():
@@ -84,13 +84,13 @@ class Settings(object):
             return True
 
         encrypted_message = open(self.settings_path, u"rb").read()
-        messages = decrypt(encrypted_message)
+        messages = decrypt(encrypted_message, password)
         if not messages:
             # Password file did not exist, set new settings
             print(ANSI.format(u"\n[ERROR] The hashed password file does not longer exist. You must re-enter settings.", u"announcer"))
             input(u"\nPres enter to continue.")
             self.set_settings()
-            return self.load_settings()
+            return self.load_settings("")
         else:
             messages = messages.decode(u"utf-8").split(u"\n")
 
@@ -252,7 +252,7 @@ class Settings(object):
 
     def show(self, quit=True):
         """ Show the current settings, if quit=True, sys.exit after user confirmation """
-        valid_token = self.load_settings()
+        valid_token = self.load_settings("")
 
         self.print_settings(first_time_setup=False, clear=True)
         self.print_advanced_settings(clear=False)

--- a/CanvasSync/usage.py
+++ b/CanvasSync/usage.py
@@ -37,17 +37,22 @@ institutions Canvas web server to a mirrored folder on their local computer.
 
 Usage
 -----
-$ canvas.py [-h] <help> [-s] <reset settings> [-i] <show current settings>
+$ canvas.py [-S] <sync> [-h] <help> [-s] <reset settings> [-i] <show current settings>
+    [-p {password}] <specify password>
 
-    -h [--help], optional  : Show this help screen.
+    -h [--help], optional                : Show this help screen.
 
-    -s [--setup], optional : Enter settings setup screen.
+    -S [--sync], optional                : Synchronize with Canvas
 
-                             The first time CanvasSync is launched settings must be set. Invoking
-                             CanvasSync with the -s or --setup flags will allow the user to reset
-                             these settings.
+    -s [--setup], optional               : Enter settings setup screen.
 
-    -i [--info], optional  : Show currently active settings.
+                                           The first time CanvasSync is launched settings must be set. Invoking
+                                           CanvasSync with the -s or --setup flags will allow the user to reset
+                                           these settings.
+
+    -i [--info], optional                : Show currently active settings.
+
+    -p {password} [--password], optional : Specify settings file decryption password (potentially dangerous)
 
 Setup
 -----

--- a/CanvasSync/usage.py
+++ b/CanvasSync/usage.py
@@ -52,7 +52,7 @@ $ canvas.py [-S] <sync> [-h] <help> [-s] <reset settings> [-i] <show current set
 
     -i [--info], optional                : Show currently active settings.
 
-    -p {password} [--password], optional : Specify settings file decryption password (potentially dangerous)
+    -p {password}, optional              : Specify settings file decryption password (potentially dangerous)
 
 Setup
 -----

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ When launched without commandline arguments, CanvasSync will start synchronizing
 prompt the user to enter new settings if no previous settings could be found.
 
 Command line arguments:
--S or --sync will synchronize according to specified settings
 -i or --info will display the currently saved settings
 -s or --setup will prompt the user to reinitialize settings
 -h or --help will show the help screen
--p or --password allows you to specify your settings file decryption password from the command line (potentially dangerous)
+-S or --sync to synchronize
+-p to specify settings password (potentially dangerous)
 
 Setup
 ----------

--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ When launched without commandline arguments, CanvasSync will start synchronizing
 prompt the user to enter new settings if no previous settings could be found.
 
 Command line arguments:
+-S or --sync will synchronize according to specified settings
 -i or --info will display the currently saved settings
 -s or --setup will prompt the user to reinitialize settings
 -h or --help will show the help screen
+-p or --password allows you to specify your settings file decryption password from the command line (potentially dangerous)
 
 Setup
 ----------

--- a/bin/canvas.py
+++ b/bin/canvas.py
@@ -13,9 +13,7 @@ CanvasSync.py, main module
 Implements the main module of CanvasSync. This module initiates the top-level Synchronizer object with the
 settings specified in the settings file. If no settings file can be found, the user is promoted to supply the
 information.
-
-The main module may take input from the command line and will act accordingly. Without command line arguments,
-CanvasSync enter a main menu where the user is guided to either set settings, show previously set settings, show help,
+The main module may take input from the command line and will act accordingly. Without command line arguments, CanvasSync enter a main menu where the user is guided to either set settings, show previously set settings, show help,
 quit of start the synchronization process.
 
 The module takes the arguments -h or --help that will show a help screen and quit.
@@ -62,7 +60,7 @@ def run_canvas_sync():
 
     # Get command line arguments (C-style)
     try:
-        opts, args = getopt.getopt(sys.argv[1:], u"hsi", [u"help", u"setup", u"info"])
+        opts, args = getopt.getopt(sys.argv[1:], u"hsiSp:", [u"help", u"setup", u"info", u"sync", u"password"])
     except getopt.GetoptError as err:
         # print help information and exit
         print(err)
@@ -71,6 +69,9 @@ def run_canvas_sync():
     # Parse the command line arguments and act accordingly
     setup = False
     show_info = False
+    manual_sync = False
+    password = ""
+
     if len(opts) != 0:
         for o, a in opts:
             if o in (u"-h", u"--help"):
@@ -84,6 +85,15 @@ def run_canvas_sync():
             elif o in (u"-i", u"--info"):
                 # Show current settings
                 show_info = True
+
+            elif o in (u"-S", u"--sync"):
+                # Force sync
+                manual_sync = True
+
+            elif o in (u"-p", u"--password"):
+                # Specify decyption password
+                print ("Warning: entering password via command line can be dangerous")
+                password = a.rstrip()
 
             else:
                 # Unknown option
@@ -100,9 +110,13 @@ def run_canvas_sync():
     if show_info:
         settings.show(quit=True)
 
+    # If -S or --sync was specified, sync and exit
+    if manual_sync:
+        do_sync(settings, password)
+        sys.exit()
+
     # If here, CanvasSync was launched without parameters, show main screen
     main_menu(settings)
-
 
 def main_menu(settings):
     """ Main menu function, calss the settings.show_main_screen function and handles user response """
@@ -120,22 +134,24 @@ def main_menu(settings):
     elif to_do == u"show_help":
         usage.help()
     else:
-        # Initialize the Instructure Api object used to make API calls to the Canvas server
-        valid_token = settings.load_settings()
-        if not valid_token:
-            settings.print_auth_token_reset_error()
-            sys.exit()
+        do_sync(settings)
 
-        # Initialize the API object
-        api = InstructureApi(settings)
+def do_sync(settings, password):
+    # Initialize the Instructure Api object used to make API calls to the Canvas server
+    valid_token = settings.load_settings(password)
+    if not valid_token:
+        settings.print_auth_token_reset_error()
+        sys.exit()
 
-        # Start Synchronizer with the current settings
-        synchronizer = Synchronizer(settings=settings, api=api)
-        synchronizer.sync()
+    # Initialize the API object
+    api = InstructureApi(settings)
 
-        # If here, sync was completed, show prompt
-        print(ANSI.format(u"\n\n[*] Sync complete", formatting=u"bold"))
+    # Start Synchronizer with the current settings
+    synchronizer = Synchronizer(settings=settings, api=api)
+    synchronizer.sync()
 
+    # If here, sync was completed, show prompt
+    print(ANSI.format(u"\n\n[*] Sync complete", formatting=u"bold"))
 
 # If main module
 if __name__ == u"__main__":

--- a/bin/canvas.py
+++ b/bin/canvas.py
@@ -13,7 +13,8 @@ CanvasSync.py, main module
 Implements the main module of CanvasSync. This module initiates the top-level Synchronizer object with the
 settings specified in the settings file. If no settings file can be found, the user is promoted to supply the
 information.
-The main module may take input from the command line and will act accordingly. Without command line arguments, CanvasSync enter a main menu where the user is guided to either set settings, show previously set settings, show help,
+The main module may take input from the command line and will act accordingly. Without command line arguments, 
+CanvasSync enter a main menu where the user is guided to either set settings, show previously set settings, show help,
 quit of start the synchronization process.
 
 The module takes the arguments -h or --help that will show a help screen and quit.


### PR DESCRIPTION
This implements the feature of triggering the sync without needing to go through the interactive interface. For example:
```
canvas.py -S
```
or
```
canvas.py --sync
```
This will prompt for the decryption password and then synchronize. If one wishes to bypass the password prompt, one may type:
```
canvas.py --S -p myPassword
```
or
```
canvas.py --sync -p myPassword
```
If you do this, you'll additionally get the message:
```
Warning: entering password via command line can be dangerous
```
Aside from convenience, this also allows shell scripts and the like to interact with CanvasSync in a very easy way. Personally, I really wanted these features so that I could make a cron job that will automatically sync my Canvas files every day!