### PR TITLE
Allow the usage of course nicknames instead of course codes

### DIFF
--- a/CanvasSync/CanvasEntities/assignment.py
+++ b/CanvasSync/CanvasEntities/assignment.py
@@ -89,7 +89,12 @@ class Assignment(Entity):
         # Get URL pointing to file objects described somewhere in the description section
 
         # Get file URLs pointing to Canvas items
-        canvas_file_urls = re.findall(r'data-api-endpoint=\"(.*?)\"', self.assignment_info[u"description"])
+        canvas_file_urls = []
+
+        try:
+            canvas_file_urls = re.findall(r'data-api-endpoint=\"(.*?)\"', self.assignment_info[u"description"])
+        except:
+            canvas_file_urls = []
 
         # Download information on all found files and add File objects to the children
         for url in canvas_file_urls:

--- a/CanvasSync/CanvasEntities/course.py
+++ b/CanvasSync/CanvasEntities/course.py
@@ -41,7 +41,7 @@ from CanvasSync.Statics import static_functions
 class Course(Entity):
     """ Derived class of the Entity base class """
 
-    def __init__(self, course_info, parent):
+    def __init__(self, course_info, parent, settings):
         """
         Constructor method, initializes base Entity class and adds all children Module objects to the list of children
 
@@ -52,10 +52,11 @@ class Course(Entity):
         self.course_info = course_info
 
         course_id = self.course_info[u"id"]
+
         course_name = static_functions.get_corrected_name(self.course_info[u"course_code"].split(";")[-1])
 
-        # Make this an option here TODO
-        course_name = self.course_info[u"name"]
+        if settings.use_nicknames:
+            course_name = self.course_info[u"name"]
 
         course_path = parent.get_path() + course_name
 

--- a/CanvasSync/CanvasEntities/course.py
+++ b/CanvasSync/CanvasEntities/course.py
@@ -54,6 +54,9 @@ class Course(Entity):
         course_id = self.course_info[u"id"]
         course_name = static_functions.get_corrected_name(self.course_info[u"course_code"].split(";")[-1])
 
+        # Make this an option here TODO
+        course_name = self.course_info[u"name"]
+
         course_path = parent.get_path() + course_name
 
         self.to_be_synced = True if course_name in parent.settings.courses_to_sync else False

--- a/CanvasSync/CanvasEntities/synchronizer.py
+++ b/CanvasSync/CanvasEntities/synchronizer.py
@@ -93,7 +93,7 @@ class Synchronizer(Entity):
             self.entities[course_information[u"id"]] = []
 
             # Create Course object
-            course = Course(course_information, parent=self, settings=settings)
+            course = Course(course_information, parent=self, settings=self.settings)
             self.add_child(course)
 
     def walk(self):

--- a/CanvasSync/CanvasEntities/synchronizer.py
+++ b/CanvasSync/CanvasEntities/synchronizer.py
@@ -93,7 +93,7 @@ class Synchronizer(Entity):
             self.entities[course_information[u"id"]] = []
 
             # Create Course object
-            course = Course(course_information, parent=self)
+            course = Course(course_information, parent=self, settings=settings)
             self.add_child(course)
 
     def walk(self):

--- a/CanvasSync/Settings/settings.py
+++ b/CanvasSync/Settings/settings.py
@@ -180,6 +180,8 @@ class Settings(object):
             self.avoid_duplicates = user_prompter.ask_for_avoid_duplicates(self)
 
             self.use_nicknames = user_prompter.ask_for_use_nicknames(self)
+            if self.use_nicknames:
+                self.courses_to_sync = user_prompter.ask_for_courses(self, api=self.api)
 
     def write_settings(self):
         self.print_settings(first_time_setup=False, clear=True)

--- a/CanvasSync/Settings/settings.py
+++ b/CanvasSync/Settings/settings.py
@@ -59,6 +59,7 @@ class Settings(object):
         self.sync_assignments = True
         self.download_linked = True
         self.avoid_duplicates = True
+        self.use_nicknames = False
 
         # Get the path pointing to the settings file.
         self.settings_path = os.path.abspath(os.path.expanduser(u"~") + u"/.CanvasSync.settings")
@@ -121,6 +122,10 @@ class Settings(object):
 
             if message[:17] == u"Avoid duplicates$":
                 self.avoid_duplicates = True if message.split(u"$")[-1] == u"True" else False
+                
+            if message[:14] == u"Use nicknames$":
+                self.use_nicknames = True if message.split(u"$")[-1] == u"True" else False
+
 
         if not static_functions.validate_token(self.domain, self.token):
             return False
@@ -174,6 +179,8 @@ class Settings(object):
 
             self.avoid_duplicates = user_prompter.ask_for_avoid_duplicates(self)
 
+            self.use_nicknames = user_prompter.ask_for_use_nicknames(self)
+
     def write_settings(self):
         self.print_settings(first_time_setup=False, clear=True)
         self.print_advanced_settings(clear=False)
@@ -192,6 +199,7 @@ class Settings(object):
             settings += u"Assignments$" + str(self.sync_assignments) + u"\n"
             settings += u"Linked files$" + str(self.download_linked) + u"\n"
             settings += u"Avoid duplicates$" + str(self.avoid_duplicates)
+            settings += u"Use nicknames$" + str(self.use_nicknames)
 
             out_file.write(encrypt(settings))
 
@@ -221,6 +229,7 @@ class Settings(object):
         print(ANSI.BOLD + u"[*] Sync assignments:         \t" + ANSI.ENDC + (ANSI.GREEN if self.sync_assignments else ANSI.RED) + str(self.sync_assignments) + ANSI.ENDC)
         print(ANSI.BOLD + u"[*] Download linked files:    \t" + ANSI.ENDC + (ANSI.GREEN if self.download_linked else ANSI.RED) + str(self.download_linked) + ANSI.ENDC)
         print(ANSI.BOLD + u"[*] Avoid item duplicates:    \t" + ANSI.ENDC + (ANSI.GREEN if self.avoid_duplicates else ANSI.RED) + str(self.avoid_duplicates) + ANSI.ENDC)
+        print(ANSI.BOLD + u"[*] Use course nicknames:     \t" + ANSI.ENDC + (ANSI.GREEN if self.use_nicknames else ANSI.RED) + str(self.use_nicknames) + ANSI.ENDC)
 
     def print_settings(self, first_time_setup=True, clear=True):
         """ Print the settings currently in memory. Clear the console first if specified by the 'clear' parameter """

--- a/CanvasSync/Settings/user_prompter.py
+++ b/CanvasSync/Settings/user_prompter.py
@@ -379,7 +379,8 @@ def ask_for_use_nicknames(settings):
                           u"course codes for display and directory structure?\n", u"white"))
 
         print(ANSI.format(u"1) No, use course codes (default)", u"bold"))
-        print(ANSI.format(u"2) Yes, use course nicknames", u"bold"))
+        print(ANSI.format(u"2) Yes, use course nicknames (you will be \n"
+                          u"     prompted to reselect courses)", u"bold"))
 
         try:
             choice = int(input(u"\nChoose number: "))

--- a/CanvasSync/Settings/user_prompter.py
+++ b/CanvasSync/Settings/user_prompter.py
@@ -169,9 +169,11 @@ def ask_for_token(domain):
 def ask_for_courses(settings, api):
 
     courses = api.get_courses()
-#    courses = [name[u"course_code"].split(";")[-1] for name in courses]
 
-    courses = [name[u"name"] for name in courses]
+    if settings.use_nicknames: 
+        courses = [name[u"name"] for name in courses]
+    else:
+        courses = [name[u"course_code"].split(";")[-1] for name in courses]
 
     choices = [True]*len(courses)
 
@@ -361,5 +363,32 @@ def ask_for_avoid_duplicates(settings):
             return True
         elif choice == 2:
             return False
+        else:
+            continue
+
+def ask_for_use_nicknames(settings):
+    choice = -1
+
+    while choice not in (1, 2):
+        settings.print_advanced_settings(clear=True)
+        print(ANSI.format(u"\n\nCourse display name settings", u"announcer"))
+        print(ANSI.format(u"In addition to identifying courses by their couse code,\n"
+                          u"Canvas can also identify courses using user-defined\n"
+                          u"nicknames that can be specified from within the Canvas UI.\n"
+                          u"Do you want CanvasSync to use course nicknames rather than\n"
+                          u"course codes for display and directory structure?\n", u"white"))
+
+        print(ANSI.format(u"1) No, use course codes (default)", u"bold"))
+        print(ANSI.format(u"2) Yes, use course nicknames", u"bold"))
+
+        try:
+            choice = int(input(u"\nChoose number: "))
+        except ValueError:
+            continue
+
+        if choice == 1:
+            return False
+        elif choice == 2:
+            return True
         else:
             continue

--- a/CanvasSync/Settings/user_prompter.py
+++ b/CanvasSync/Settings/user_prompter.py
@@ -169,7 +169,9 @@ def ask_for_token(domain):
 def ask_for_courses(settings, api):
 
     courses = api.get_courses()
-    courses = [name[u"course_code"].split(";")[-1] for name in courses]
+#    courses = [name[u"course_code"].split(";")[-1] for name in courses]
+
+    courses = [name[u"name"] for name in courses]
 
     choices = [True]*len(courses)
 

--- a/bin/canvas.py
+++ b/bin/canvas.py
@@ -135,7 +135,7 @@ def main_menu(settings):
     elif to_do == u"show_help":
         usage.help()
     else:
-        do_sync(settings)
+        do_sync(settings, "")
 
 def do_sync(settings, password):
     # Initialize the Instructure Api object used to make API calls to the Canvas server


### PR DESCRIPTION
My university's course codes are simply _horrendous_ (for example, _Fa17 MATH-2210-504_ for a calc recitation). Luckily, Canvas allows users to nickname courses to whatever they'd like to make them more human-readable and fun when I can rename my Discrete Mathematics class "Enlightenment of the Math Gods" or my Programming Languages class "Haskell et al."

This PR allows users to tell CanvasSync in the advanced settings to use these course nicknames instead of course codes. This affects the directory names as well as CanvasSync's display and internal list of the courses.

The setting is not enabled by default. :)