### PR TITLE
Fixed _version issue on Archlinux

### DIFF
--- a/CanvasSync/__init__.py
+++ b/CanvasSync/__init__.py
@@ -1,3 +1,3 @@
 """ CanvasSync by Mathias Perslev """
 
-from _version import __version__
+from ._version import __version__


### PR DESCRIPTION
This is a fix for an issue on Archlinux where the program cannot be run because it can't find _version.
Error looked like this:
```
[dklug@stillalive4 ~]$ sudo canvas.py
Traceback (most recent call last):
  File "/usr/bin/canvas.py", line 43, in <module>
    from CanvasSync.CanvasEntities.synchronizer import Synchronizer
  File "/usr/lib/python3.6/site-packages/CanvasSync/__init__.py", line 3, in <module>
    from _version import __version__
ModuleNotFoundError: No module named '_version'
```
I tested this change on Ubuntu just in case and it didn't break anything.