### PR TITLE
restricted courses errors

### DIFF
--- a/CanvasSync/entities/course.py
+++ b/CanvasSync/entities/course.py
@@ -47,10 +47,13 @@ class Course(CanvasEntity):
 
         course_id = self.course_info[u"id"]
 
-        course_name = helpers.get_corrected_name(self.course_info[u"course_code"].split(";")[-1])
+        if "course_code" in course_info:
+            course_name = helpers.get_corrected_name(self.course_info[u"course_code"].split(";")[-1])
 
-        if settings.use_nicknames:
-            course_name = self.course_info[u"name"]
+            if settings.use_nicknames:
+                course_name = self.course_info[u"name"]
+        else:
+            course_name = "Nothing"
 
         course_path = parent.get_path() + course_name
 

--- a/CanvasSync/settings/user_prompter.py
+++ b/CanvasSync/settings/user_prompter.py
@@ -168,7 +168,13 @@ def ask_for_courses(settings, api):
     if settings.use_nicknames: 
         courses = [name[u"name"] for name in courses]
     else:
-        courses = [name[u"course_code"].split(";")[-1] for name in courses]
+        course_after = []
+        for name in courses:
+            if "course_code" in name:
+                course_after = course_after + [name[u"course_code"].split(";")[-1]]
+            else:
+                course_after = course_after + [u'nothing']
+        courses = course_after
 
     choices = [True]*len(courses)
 


### PR DESCRIPTION
Encountering the same errors in #19. Tried to fix it.
PDB debugging outputs:
```
> /Users/jinboci/Documents/anaconda3/lib/python3.7/site-packages/CanvasSync/settings/user_prompter.py(162)ask_for_courses()
-> if settings.use_nicknames:
(Pdb) n
> /Users/jinboci/Documents/anaconda3/lib/python3.7/site-packages/CanvasSync/settings/user_prompter.py(165)ask_for_courses()
-> courses = [name[u"course_code"].split(";")[-1] for name in courses]
(Pdb) ["course_code" in name for name in courses]
[True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True]
(Pdb) courses[4]
{'id': 377800, 'access_restricted_by_date': True}
```