### PR TITLE
Validate Domain fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 __pycache__
+build
+dist
+*.egg-info

--- a/CanvasSync/utilities/helpers.py
+++ b/CanvasSync/utilities/helpers.py
@@ -124,9 +124,8 @@ def validate_domain(domain):
     interpreting the HTTP response
     """
     try:
-        response = requests.get(domain + u"/api/v1/courses", timeout=5).text
-        if (response == u"{\"status\":\"unauthenticated\",\"errors\":[{\"message\":\"user authorisation required\"}]}" or
-            response == u"{\"status\":\"unauthenticated\",\"errors\":[{\"message\":\"user authorization required\"}]}"):
+        response = requests.get(domain + u"/api/v1/courses", timeout=5)
+        if response.status_code==401:
             # If this response, the server exists and understands
             # the API call but complains that the call was
             # not authenticated - the URL represents a Canvas server


### PR DESCRIPTION
`helpers/validate_domain` function checks for the response's HTTP status code instead of hard-coded text.

This fixes #25.
