### PR TITLE
fix naming convention in user prompter so courses with invalid names still sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__
 build
 dist
 *.egg-info
+.DS_Store
+*.pyc

--- a/CanvasSync/settings/user_prompter.py
+++ b/CanvasSync/settings/user_prompter.py
@@ -165,10 +165,10 @@ def ask_for_courses(settings, api):
 
     courses = api.get_courses()
 
-    if settings.use_nicknames: 
+    if settings.use_nicknames:
         courses = [name[u"name"] for name in courses]
     else:
-        courses = [name[u"course_code"].split(";")[-1] for name in courses]
+        courses = [helpers.get_corrected_name(name[u"course_code"].split(";")[-1]) for name in courses]
 
     choices = [True]*len(courses)
 


### PR DESCRIPTION
This resolves an issue where, e.g., a course named "FNCE/REAL 123" doesn't sync even if set to, because in `course.py` "FNCE/REAL 123" is converted to "FNCE_REAL 123", but the list of courses to sync still has "FNCE/REAL 123".