### PR TITLE
Fix CanvasSync crashes for expired courses

### DIFF
--- a/CanvasSync/settings/user_prompter.py
+++ b/CanvasSync/settings/user_prompter.py
@@ -164,6 +164,7 @@ def ask_for_token(domain):
 def ask_for_courses(settings, api):
 
     courses = api.get_courses()
+    courses = [course for course in courses if 'access_restricted_by_date' not in course]
 
     if settings.use_nicknames:
         courses = [name[u"name"] for name in courses if "name" in name]


### PR DESCRIPTION
I ran into this error repeatedly when trying to run CanvasSync:

```
Traceback (most recent call last):
  File "~/.pyenv/versions/3.8.16/bin/canvas", line 33, in <module>
    sys.exit(load_entry_point('CanvasSync==0.2.4', 'console_scripts', 'canvas')())
  File "~/.pyenv/versions/3.8.16/lib/python3.8/site-packages/bin/canvas.py", line 187, in entry
    run_canvas_sync()
  File "~/.pyenv/versions/3.8.16/lib/python3.8/site-packages/bin/canvas.py", line 132, in run_canvas_sync
    main_menu(settings)
  File "~/.pyenv/versions/3.8.16/lib/python3.8/site-packages/bin/canvas.py", line 146, in main_menu
    settings.set_settings()
  File "~/.pyenv/versions/3.8.16/lib/python3.8/site-packages/CanvasSync/settings/settings.py", line 152, in set_settings
    self._set_settings()
  File "~/.pyenv/versions/3.8.16/lib/python3.8/site-packages/CanvasSync/settings/settings.py", line 180, in _set_settings
    self.courses_to_sync = user_prompter.ask_for_courses(self, api=self.api)
  File "~/.pyenv/versions/3.8.16/lib/python3.8/site-packages/CanvasSync/settings/user_prompter.py", line 171, in ask_for_courses
    courses = [name[u"course_code"].split(";")[-1] for name in courses]
  File "~/.pyenv/versions/3.8.16/lib/python3.8/site-packages/CanvasSync/settings/user_prompter.py", line 171, in <listcomp>
    courses = [name[u"course_code"].split(";")[-1] for name in courses]
KeyError: 'course_code'
```

I checked the keys in the dict for each of the courses returned by the API and found that 'access_restricted_by_date' marked particular courses that did not have the typical set of keys.

```
Available keys: dict_keys(['id', 'access_restricted_by_date'])
Available keys: dict_keys(['id', 'access_restricted_by_date'])
Available keys: dict_keys(['id', 'name', 'account_id', 'uuid', 'start_at', 'grading_standard_id', 'is_public', 'created_at', 'course_code', 'default_view', 'root_account_id', 'enrollment_term_id', 'license', 'grade_passback_setting', 'end_at', 'public_syllabus', 'public_syllabus_to_auth', 'storage_quota_mb', 'is_public_to_auth_users', 'homeroom_course', 'course_color', 'friendly_name', 'apply_assignment_group_weights', 'calendar', 'time_zone', 'blueprint', 'template', 'enrollments', 'hide_final_grades', 'workflow_state', 'restrict_enrollments_to_course_dates'])
Available keys: dict_keys(['id', 'name', 'account_id', 'uuid', 'start_at', 'grading_standard_id', 'is_public', 'created_at', 'course_code', 'default_view', 'root_account_id', 'enrollment_term_id', 'license', 'grade_passback_setting', 'end_at', 'public_syllabus', 'public_syllabus_to_auth', 'storage_quota_mb', 'is_public_to_auth_users', 'homeroom_course', 'course_color', 'friendly_name', 'apply_assignment_group_weights', 'calendar', 'time_zone', 'blueprint', 'template', 'enrollments', 'hide_final_grades', 'workflow_state', 'restrict_enrollments_to_course_dates'])
// ...
```

This PR fixes that by filtering for courses that the student actually is allowed to access.
