### PR TITLE
Updated Windows warning and password checks

### DIFF
--- a/CanvasSync/settings/cryptography.py
+++ b/CanvasSync/settings/cryptography.py
@@ -43,8 +43,8 @@ def encrypt(message):
     """
 
     print(u"\nPlease enter a password to encrypt the settings file:")
-    hashed_password = bcrypt.hashpw(getpass.getpass(), bcrypt.gensalt())
-    with open(os.path.expanduser(u"~") + u"/.CanvasSync.pw", "w") as pass_file:
+    hashed_password = bcrypt.hashpw(getpass.getpass().encode(), bcrypt.gensalt())
+    with open(os.path.expanduser(u"~") + u"/.CanvasSync.pw", "wb") as pass_file:
         pass_file.write(hashed_password)
 
     # Generate random 16 bytes IV
@@ -77,7 +77,7 @@ def decrypt(message, password):
 
     # If the password isn't null then it was specified as a command-line argument
     if password:
-        if bcrypt.hashpw(password, hashed_password) != hashed_password:
+        if not bcrypt.checkpw(password.encode(), hashed_password.encode()):
             print(u"\n[ERROR] Invalid password. Please try again or invoke CanvasSync with the -s flag to reset settings.")
             sys.exit()
     else:
@@ -85,7 +85,7 @@ def decrypt(message, password):
         while not valid_password:
             print(u"\nPlease enter password to decrypt the settings file:")
             password = getpass.getpass()
-            if bcrypt.hashpw(password, hashed_password) == hashed_password:
+            if bcrypt.checkpw(password.encode(), hashed_password.encode()):
                 valid_password = True
             else:
                 print(u"\n[ERROR] Invalid password. Please try again or invoke CanvasSync with the -s flag to reset settings.")

--- a/bin/canvas.py
+++ b/bin/canvas.py
@@ -177,11 +177,10 @@ def entry():
     if os.name == u"nt":
         # Warn Windows users
         helpers.clear_console()
-        input(u"\n[OBS] You are running CanvasSync on a Windows operating system.\n"
+        print(u"\n[OBS] You are running CanvasSync on a Windows operating system.\n"
                   u"      The application is not developed for Windows machines and may be\n"
                   u"      unstable. Some pretty output formatting and tab-autocompletion\n"
-                  u"      is not supported... :-(\n"
-                  u"\n    Anyway, hit enter to start.")
+                  u"      is not supported... :-(\n")
 
     try:
         run_canvas_sync()


### PR DESCRIPTION
This PR does the following:


1. Remove the need for user input on Windows Systems
The `canvas.entry` method requires a Windows User to hit enter after reading a warning. This prevents the tool from being used in automated tasks. A better way to do this might be to detect if the user is running with arguments, and not show the warning in that case, but show the warning when there are no arguments.

2. Update the password checks
The calls to `bcrypt`'s `hashpw` were not encoding the password as bytes, and `hashpw` was used to verify password's rather than `bcrypt`'s provided `checkpw` which is intended for that process. This causes a`TypeError` crash, as shown below.

![Crash-due-to-Password-types](https://github.com/perslev/CanvasSync/assets/48603340/f5e44b9f-9a3b-4af2-a8a6-81db92d189cd)
