### PR TITLE
Fix for issue #45 and issue #19

### DIFF
--- a/CanvasSync/settings/cryptography.py
+++ b/CanvasSync/settings/cryptography.py
@@ -45,7 +45,8 @@ def encrypt(message):
     print(u"\nPlease enter a password to encrypt the settings file:")
     hashed_password = bcrypt.hashpw(getpass.getpass().encode(), bcrypt.gensalt())
     with open(os.path.expanduser(u"~") + u"/.CanvasSync.pw", "wb") as pass_file:
-        pass_file.write(hashed_password)
+        # Fix TypeError: a bytes-like object is required, not 'str'
+        pass_file.write(str.encode(hashed_password))
 
     # Generate random 16 bytes IV
     IV = os.urandom(16)

--- a/CanvasSync/settings/user_prompter.py
+++ b/CanvasSync/settings/user_prompter.py
@@ -169,7 +169,9 @@ def ask_for_courses(settings, api):
     if settings.use_nicknames:
         courses = [name[u"name"] for name in courses if "name" in name]
     else:
-        courses = [helpers.get_corrected_name(name[u"course_code"].split(";")[-1]) for name in courses if "course_code" in name]
+        #  exclude courses that do not have a 'course_code'
+        courses = [name[u"course_code"].split(";")[-1] for name in courses if 'course_code' in name
+]
 
     choices = [True]*len(courses)
 


### PR DESCRIPTION
Fix for issue https://github.com/perslev/CanvasSync/issues/45 TypeError: a bytes-like object is required, not 'str' in criptography.py and issue https://github.com/perslev/CanvasSync/issues/19 KeyError: 'course_code' when there are unactivated courses on Canvas