### PR TITLE
Fix weird course names not matching in settings

### DIFF
--- a/CanvasSync/settings/user_prompter.py
+++ b/CanvasSync/settings/user_prompter.py
@@ -210,7 +210,7 @@ def ask_for_courses(settings, api):
 
     print(choices)
 
-    return [x for index, x in enumerate(courses) if choices[index]]
+    return [helpers.get_corrected_name(x) for index, x in enumerate(courses) if choices[index]]
 
 
 def ask_for_advanced_settings(settings):


### PR DESCRIPTION
Did the same sanitation process before writing to directory.