### PR TITLE
Add error handling for Course creation

### DIFF
--- a/CanvasSync/entities/synchronizer.py
+++ b/CanvasSync/entities/synchronizer.py
@@ -96,9 +96,12 @@ class Synchronizer(CanvasEntity):
             self.entities[course_information[u"id"]] = []
 
             # Create Course object
-            course = Course(course_information,
-                            parent=self,
-                            settings=self.settings)
+            try:
+                course = Course(course_information,
+                                parent=self,
+                                settings=self.settings
+            except KeyError:
+                continue
             self.add_child(course)
 
     def walk(self):


### PR DESCRIPTION
Handle KeyError when creating Course object. This occurs when "ghost" courses appear, that do not have a course_id associated with them. Fixes #19 .